### PR TITLE
Improve AGENTS guidance on Miri and contributions

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -31,3 +31,9 @@ and tips that help future contributors. Keep entries brief yet informative.
 
 This document is short-term memory. Run `bash scripts/setup.sh` once to install
 tools, then `bash .agent/hooks/pre-push.sh` before pushing.
+
+### Notes
+- Miri runs tests in an isolated environment without access to OS operations like opening directories. Any test that reads from the filesystem should either be skipped with `#[cfg(not(miri))]` or rewritten to avoid directory reads when running under Miri.
+
+### Maintaining this file
+- When updating AGENTS.md, provide context and reasoning that future contributors can apply. Avoid notes that only explain a workaround without describing the underlying issue.

--- a/crates/flameview/src/lib.rs
+++ b/crates/flameview/src/lib.rs
@@ -5,6 +5,7 @@ pub fn add_one(x: i32) -> i32 {
 
 pub mod arena;
 pub use arena::{FlameTree, Node, NodeId};
+pub mod loader;
 
 #[cfg(test)]
 mod tests {

--- a/crates/flameview/src/loader/collapsed.rs
+++ b/crates/flameview/src/loader/collapsed.rs
@@ -1,0 +1,34 @@
+use std::io::Read;
+
+use crate::arena::FlameTree;
+use crate::loader::Error;
+
+pub fn load<R: Read>(mut r: R) -> Result<FlameTree, Error> {
+    let mut s = String::new();
+    r.read_to_string(&mut s)?;
+    let mut tree = FlameTree::new();
+    let mut scratch = Vec::new();
+    for (line_no, raw) in s.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Some(space) = line.rfind(' ') else {
+            return Err(Error::BadLine(line_no + 1));
+        };
+        let (stack_str, cnt_str) = line.split_at(space);
+        let count: u64 = cnt_str
+            .trim_start()
+            .parse()
+            .map_err(|_| Error::BadLine(line_no + 1))?;
+        scratch.clear();
+        let mut parent = tree.root();
+        for frame in stack_str.split(';') {
+            let id = tree.get_or_insert_child(parent, frame);
+            scratch.push(id);
+            parent = id;
+        }
+        tree.add_samples(parent, count);
+    }
+    Ok(tree)
+}

--- a/crates/flameview/src/loader/mod.rs
+++ b/crates/flameview/src/loader/mod.rs
@@ -1,0 +1,13 @@
+pub mod collapsed;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(std::io::Error),
+    BadLine(usize),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}

--- a/crates/flameview/tests/collapsed_basic.rs
+++ b/crates/flameview/tests/collapsed_basic.rs
@@ -1,0 +1,6 @@
+#[test]
+fn totals_basic() {
+    let input = "a;b 3\na;c 2\n";
+    let tree = flameview::loader::collapsed::load(input.as_bytes()).unwrap();
+    assert_eq!(tree.total_samples(), 5);
+}

--- a/crates/flameview/tests/collapsed_suite.rs
+++ b/crates/flameview/tests/collapsed_suite.rs
@@ -1,0 +1,20 @@
+use std::fs;
+#[cfg(not(miri))]
+#[test]
+fn totals_match_fixture_names() {
+    for entry in fs::read_dir("../../tests/data").unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|s| s.to_str()) == Some("txt") {
+            let data = fs::read(&path).unwrap();
+            let tree = flameview::loader::collapsed::load(data.as_slice()).unwrap();
+            if let Some(num) = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.rsplit('-').next())
+                .and_then(|s| s.parse::<u64>().ok())
+            {
+                assert_eq!(tree.total_samples(), num, "file {path:?}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- clarify why Miri can't run directory-based tests
- add policy for useful AGENTS.md updates

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude flameview-fuzz --all-targets --all-features -- -D warnings` *(failed: environment limits)*
- `cargo test -p flameview --test collapsed_basic --test collapsed_suite --no-fail-fast` *(failed: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_688af24e4b288320a223f80a1e0edb9d