### PR TITLE
Fix Miri tests with conditional file attribute

### DIFF
--- a/crates/flameview/tests/collapsed_suite.rs
+++ b/crates/flameview/tests/collapsed_suite.rs
@@ -1,5 +1,6 @@
+#![cfg(not(miri))]
 use std::fs;
-#[cfg(not(miri))]
+
 #[test]
 fn totals_match_fixture_names() {
     for entry in fs::read_dir("../../tests/data").unwrap() {


### PR DESCRIPTION
## Summary
- skip `collapsed_suite` tests entirely when running under Miri

## Testing
- `bash .agent/hooks/pre-push.sh`
- `cargo +nightly miri test -p flameview --all-features`

------
https://chatgpt.com/codex/tasks/task_e_688b13f8334c8320bf34d9493505d7de