### PR TITLE
Implement summarize functionality

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -35,5 +35,9 @@ tools, then `bash .agent/hooks/pre-push.sh` before pushing.
 ### Notes
 - Miri runs tests in an isolated environment without access to OS operations like opening directories. Any test that reads from the filesystem should either be skipped with `#[cfg(not(miri))]` or rewritten to avoid directory reads when running under Miri.
 
+### Snapshot testing
+- Use [`insta`](https://insta.rs/) for inline snapshots.
+- After modifying snapshots, run `cargo insta review` to accept new outputs.
+
 ### Maintaining this file
 - When updating AGENTS.md, provide context and reasoning that future contributors can apply. Avoid notes that only explain a workaround without describing the underlying issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +449,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "indexmap",
+ "insta",
  "quickcheck",
  "roxmltree",
  "smallvec",
@@ -549,6 +568,17 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
 ]
 
 [[package]]
@@ -1151,6 +1181,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/crates/flameview/Cargo.toml
+++ b/crates/flameview/Cargo.toml
@@ -13,6 +13,7 @@ roxmltree = "0.19"
 [dev-dependencies]
 quickcheck = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
+insta = "1"
 
 [[bench]]
 name = "add_one"

--- a/crates/flameview/src/lib.rs
+++ b/crates/flameview/src/lib.rs
@@ -6,6 +6,7 @@ pub fn add_one(x: i32) -> i32 {
 pub mod arena;
 pub use arena::{FlameTree, Node, NodeId};
 pub mod loader;
+mod summarize;
 
 #[cfg(test)]
 mod tests {

--- a/crates/flameview/src/summarize.rs
+++ b/crates/flameview/src/summarize.rs
@@ -1,0 +1,75 @@
+use std::collections::VecDeque;
+
+use crate::arena::{FlameTree, NodeId};
+
+impl FlameTree {
+    /// Pretty-prints an indented overview of the flame tree.
+    ///
+    /// * `max_lines` – maximum non-root rows to emit (root is always shown)
+    /// * `coverage`  – stop early once cumulative inclusive samples
+    ///   reach this fraction of total (0.0‒1.0).
+    ///
+    /// Returns a ready-to-display `String`.
+    pub fn summarize(&self, max_lines: usize, coverage: f64) -> String {
+        let total = self[self.root()].total_count as f64;
+        let mut out = String::new();
+        out.push_str(&format!(
+            "(root) (100.0%, {})",
+            self[self.root()].total_count
+        ));
+
+        if total == 0.0 || max_lines == 0 || coverage <= 0.0 {
+            return out;
+        }
+
+        let mut queue: VecDeque<(NodeId, usize)> = VecDeque::new();
+        // gather root children sorted and push onto queue
+        let mut children = Vec::new();
+        let mut child = self[self.root()].first_child;
+        while let Some(id) = child {
+            children.push(id);
+            child = self[id].next_sibling;
+        }
+        children.sort_by_key(|&id| std::cmp::Reverse(self[id].total_count));
+        for id in children.into_iter().rev() {
+            queue.push_front((id, 1));
+        }
+
+        let mut printed = 0usize;
+        let mut cum_total = 0u64;
+
+        while let Some((id, depth)) = queue.pop_front() {
+            let node = &self[id];
+            out.push('\n');
+            out.push_str(&"  ".repeat(depth));
+            out.push_str(&format!(
+                "{} ({:.1}%, {})",
+                node.name,
+                node.total_count as f64 / total * 100.0,
+                node.total_count
+            ));
+            printed += 1;
+            cum_total += node.self_count;
+
+            // push children of this node
+            let mut ch = node.first_child;
+            if ch.is_some() {
+                let mut chvec = Vec::new();
+                while let Some(cid) = ch {
+                    chvec.push(cid);
+                    ch = self[cid].next_sibling;
+                }
+                chvec.sort_by_key(|&cid| std::cmp::Reverse(self[cid].total_count));
+                for cid in chvec.into_iter().rev() {
+                    queue.push_front((cid, depth + 1));
+                }
+            }
+
+            if printed >= max_lines || (cum_total as f64 / total) >= coverage {
+                break;
+            }
+        }
+
+        out
+    }
+}

--- a/crates/flameview/src/summarize.rs
+++ b/crates/flameview/src/summarize.rs
@@ -6,8 +6,9 @@ impl FlameTree {
     /// Pretty-prints an indented overview of the flame tree.
     ///
     /// * `max_lines` – maximum non-root rows to emit (root is always shown)
-    /// * `coverage`  – stop early once cumulative inclusive samples
-    ///   reach this fraction of total (0.0‒1.0).
+    /// * `coverage`  – stop early once cumulative **self** samples
+    ///   reach this fraction of total (0.0‒1.0). This avoids
+    ///   double-counting inclusive time from sibling branches.
     ///
     /// Returns a ready-to-display `String`.
     pub fn summarize(&self, max_lines: usize, coverage: f64) -> String {

--- a/crates/flameview/tests/summarize.rs
+++ b/crates/flameview/tests/summarize.rs
@@ -1,0 +1,14 @@
+#[test]
+fn summary_limits_lines_and_coverage() {
+    let data = include_str!("../../../tests/data/perl.txt");
+    let tree = flameview::loader::collapsed::load(data.as_bytes()).unwrap();
+    let out = tree.summarize(5, 0.90);
+    let n = out.lines().count();
+    assert!(n <= 6, "root + \u{2264}5 children");
+    assert!(out.contains("(root)"));
+    assert!(out.contains("  ")); // at least one indented line
+    insta::assert_snapshot!(out, @r#"(root) (100.0%, 1000)
+  foo (60.0%, 600)
+    bar (40.0%, 400)
+  baz (35.0%, 350)"#);
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,6 +15,9 @@ export PATH="$(rustc +nightly --print sysroot)/lib/rustlib/x86_64-unknown-linux-
 export PATH="$(rustc +stable --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin:$PATH"
 
 cargo +stable  install --locked cargo-nextest cargo-edit
+if ! command -v cargo-insta >/dev/null 2>&1; then
+    curl -LsSf https://insta.rs/install.sh | sh
+fi
 go install github.com/rhysd/actionlint/cmd/actionlint@latest
 cargo +nightly install --locked cargo-fuzz flamegraph
 

--- a/tests/data/perl.txt
+++ b/tests/data/perl.txt
@@ -1,0 +1,4 @@
+foo;bar 400
+foo 200
+baz 350
+other 50


### PR DESCRIPTION
## Summary
- add snapshot testing with `insta`
- refine `FlameTree::summarize` coverage logic
- document snapshot workflow in `AGENTS.md`
- install `cargo-insta` in setup script

## Testing
- `bash .agent/hooks/pre-push.sh`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_688bb6a5782c8320bab15a4f6755a6ed