### PR TITLE
Fix miri snapshot test

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -38,6 +38,7 @@ tools, then `bash .agent/hooks/pre-push.sh` before pushing.
 ### Snapshot testing
 - Use [`insta`](https://insta.rs/) for inline snapshots.
 - After modifying snapshots, run `cargo insta review` to accept new outputs.
+- Snapshot assertions do not work under Miri; guard them with `#[cfg(not(miri))]`.
 
 ### Maintaining this file
 - When updating AGENTS.md, provide context and reasoning that future contributors can apply. Avoid notes that only explain a workaround without describing the underlying issue.

--- a/crates/flameview/tests/summarize.rs
+++ b/crates/flameview/tests/summarize.rs
@@ -7,6 +7,7 @@ fn summary_limits_lines_and_coverage() {
     assert!(n <= 6, "root + \u{2264}5 children");
     assert!(out.contains("(root)"));
     assert!(out.contains("  ")); // at least one indented line
+    #[cfg(not(miri))]
     insta::assert_snapshot!(out, @r#"(root) (100.0%, 1000)
   foo (60.0%, 600)
     bar (40.0%, 400)


### PR DESCRIPTION
## Summary
- skip insta snapshot assertion when running under Miri
- document Miri limitation in AGENTS.md

## Testing
- `bash .agent/hooks/pre-push.sh`


------
https://chatgpt.com/codex/tasks/task_e_688bd8c8c3bc8320a8d816fda0ce5575