### PR TITLE
Implement CLI summarize subcommand

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -37,6 +37,7 @@ tools, then `bash .agent/hooks/pre-push.sh` before pushing.
 
 ### Snapshot testing
 - Use [`insta`](https://insta.rs/) for inline snapshots.
+- Prefer inline snapshots when verifying CLI output or other textual representations.
 - After modifying snapshots, run `cargo insta review` to accept new outputs.
 
 ### Maintaining this file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "flameview",
+ "insta",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 flameview = { path = "../flameview" }
 clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+insta = "1"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,0 +1,23 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(author, version, about)]
+pub struct Args {
+    #[command(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Summarize a collapsed stack file
+    Summarize {
+        /// Input file to read
+        file: std::path::PathBuf,
+        /// Maximum number of lines to display
+        #[arg(long, default_value_t = 50)]
+        max_lines: usize,
+        /// Fraction of self samples to cover before stopping
+        #[arg(long, default_value_t = 0.95)]
+        coverage: f64,
+    },
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,12 +1,11 @@
-use clap::Parser;
-use flameview::add_one; // will be swapped for real API in Milestone M6
+mod args;
+mod run;
 
-#[derive(Parser)]
-struct Opt {
-    #[arg(long, default_value_t = 0)]
-    value: i32,
-}
+use clap::Parser;
 
 fn main() {
-    println!("{}", add_one(Opt::parse().value));
+    let args = args::Args::parse();
+    if run::run(args).is_err() {
+        std::process::exit(1);
+    }
 }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -1,0 +1,30 @@
+use std::fs;
+
+use flameview::loader::{self, collapsed};
+
+use crate::args::{Args, Command};
+
+pub fn run(args: Args) -> Result<(), ()> {
+    match args.cmd {
+        Command::Summarize {
+            file,
+            max_lines,
+            coverage,
+        } => {
+            let data = fs::read(&file).map_err(|_| {
+                eprintln!("flameview: unable to read {}", file.display());
+            })?;
+            let tree = collapsed::load(data.as_slice()).map_err(|e| match e {
+                loader::Error::Io(_) => {
+                    eprintln!("flameview: unable to read {}", file.display());
+                }
+                loader::Error::BadLine(line) => {
+                    eprintln!("flameview: parse error on line {line}");
+                }
+            })?;
+            let summary = tree.summarize(max_lines, coverage);
+            println!("{}", summary);
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -23,7 +23,7 @@ pub fn run(args: Args) -> Result<(), ()> {
                 }
             })?;
             let summary = tree.summarize(max_lines, coverage);
-            println!("{}", summary);
+            println!("{summary}");
         }
     }
     Ok(())

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn cli_summarize_runs() {
+    let exe = env!("CARGO_BIN_EXE_flameview-cli");
+    let data_path: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "..",
+        "..",
+        "tests",
+        "data",
+        "perl.txt",
+    ]
+    .iter()
+    .collect();
+    let out = Command::new(exe)
+        .arg("summarize")
+        .arg(data_path)
+        .arg("--max-lines")
+        .arg("20")
+        .arg("--coverage")
+        .arg("0.8")
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("(root)"));
+    assert!(stdout.lines().count() <= 21);
+}

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -25,6 +25,12 @@ fn cli_summarize_runs() {
         .expect("run");
     assert!(out.status.success());
     let stdout = String::from_utf8(out.stdout).unwrap();
+    insta::assert_snapshot!(stdout, @r"
+    (root) (100.0%, 1000)
+      foo (60.0%, 600)
+        bar (40.0%, 400)
+      baz (35.0%, 350)
+    ");
     assert!(stdout.contains("(root)"));
     assert!(stdout.lines().count() <= 21);
 }


### PR DESCRIPTION
## Summary
- add a clap-powered argument parser
- implement `run` logic for the `summarize` command
- update `main` to use new modules
- add an integration test covering `flameview-cli summarize`

## Testing
- `cargo build --workspace --exclude flameview-fuzz --quiet`
- `cargo test -p flameview-cli --test cli --quiet`
- `cargo run -p flameview-cli -- summarize tests/data/perl.txt`
- `bash .agent/hooks/pre-push.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bd5ededd88320b868a0cd911ace6c