### PR TITLE
Improve fuzz target

### DIFF
--- a/fuzz/fuzz_targets/fuzz_add_one.rs
+++ b/fuzz/fuzz_targets/fuzz_add_one.rs
@@ -1,10 +1,16 @@
 #![no_main]
-use flameview::add_one;
+
+use flameview::loader::collapsed;
 use libfuzzer_sys::fuzz_target;
 
+// Feed arbitrary bytes to the collapsed loader and, when parsing
+// succeeds, exercise the summarizer with parameters derived from
+// the input. The fuzzer should never trigger a panic in either
+// stage.
 fuzz_target!(|data: &[u8]| {
-    if data.len() == 4 {
-        let v = i32::from_le_bytes(data.try_into().unwrap());
-        let _ = add_one(v);
+    if let Ok(tree) = collapsed::load(data) {
+        let max_lines = data.first().copied().unwrap_or(0) as usize;
+        let coverage = data.get(1).map(|b| *b as f64 / 255.0).unwrap_or(0.5);
+        let _ = tree.summarize(max_lines, coverage);
     }
 });


### PR DESCRIPTION
## Summary
- feed arbitrary bytes to `collapsed::load`
- ensure summarizer handles random data without panics

## Testing
- `cargo build --workspace --release --exclude flameview-fuzz`
- `cargo test --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_688bf5d461008320a68418c31ad556b2