### PR TITLE
Fix failing test under miri

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -34,6 +34,7 @@ tools, then `bash .agent/hooks/pre-push.sh` before pushing.
 
 ### Notes
 - Miri runs tests in an isolated environment without access to OS operations like opening directories. Any test that reads from the filesystem should either be skipped with `#[cfg(not(miri))]` or rewritten to avoid directory reads when running under Miri.
+- Run `cargo clippy -- -D warnings` with `RUSTFLAGS="--cfg miri"` to compile tests with the same cfg flags used by Miri. This catches unused imports or other compile errors before running Miri.
 
 ### Snapshot testing
 - Use [`insta`](https://insta.rs/) for inline snapshots.

--- a/.agent/hooks/pre-push.sh
+++ b/.agent/hooks/pre-push.sh
@@ -8,6 +8,8 @@ cargo +nightly --version >/dev/null
 cargo build --workspace --release --exclude flameview-fuzz
 cargo test  --workspace --all-features --verbose
 cargo clippy --workspace --all-targets --all-features -- -D warnings
+# Compile tests under the same cfg flags Miri uses
+RUSTFLAGS="--cfg miri" cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo +nightly fmt --all -- --check
 actionlint -color
 

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1,7 +1,8 @@
+#![cfg(not(miri))]
+
 use std::path::PathBuf;
 use std::process::Command;
 
-#[cfg(not(miri))]
 #[test]
 fn cli_summarize_runs() {
     let exe = env!("CARGO_BIN_EXE_flameview-cli");

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+#[cfg(not(miri))]
 #[test]
 fn cli_summarize_runs() {
     let exe = env!("CARGO_BIN_EXE_flameview-cli");


### PR DESCRIPTION
## Summary
- disable CLI integration test under miri

## Testing
- `cargo +nightly miri test`
- `bash .agent/hooks/pre-push.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bf47956e08320870ed0e649e99fe2