### PR TITLE
Add new benchmark to CI

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -32,6 +32,11 @@ and tips that help future contributors. Keep entries brief yet informative.
 This document is short-term memory. Run `bash scripts/setup.sh` once to install
 tools, then `bash .agent/hooks/pre-push.sh` before pushing.
 
+### Benchmarks
+- All benches live in `crates/flameview/benches/` and are executed in CI via
+  `cargo bench --package flameview`. Adding a new benchmark does not require
+  modifying workflow files.
+
 ### Notes
 - Miri runs tests in an isolated environment without access to OS operations like opening directories. Any test that reads from the filesystem should either be skipped with `#[cfg(not(miri))]` or rewritten to avoid directory reads when running under Miri.
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,18 +7,13 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bench:
-          - add_one
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Run benchmark
+      - name: Run all benchmarks
         env:
           RUSTFLAGS: "--cfg=bench"
-        run: cargo bench --package flameview --bench ${{ matrix.bench }} --verbose || true
+        run: cargo bench --package flameview --verbose || true

--- a/crates/flameview/Cargo.toml
+++ b/crates/flameview/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Compact, text-first exploration of FlameGraph data"
 license = "MIT OR Apache-2.0"
+autobenches = false
 
 [dependencies]
 smallvec = "1"
@@ -17,4 +18,8 @@ insta = "1"
 
 [[bench]]
 name = "add_one"
+harness = false
+
+[[bench]]
+name = "load_collapsed"
 harness = false

--- a/crates/flameview/benches/load_collapsed.rs
+++ b/crates/flameview/benches/load_collapsed.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::PathBuf;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use flameview::loader::collapsed;
+
+fn bench_load_collapsed(c: &mut Criterion) {
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/data");
+    let mut group = c.benchmark_group("load_collapsed");
+    for entry in fs::read_dir(&data_dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("txt") {
+            let name = entry.file_name().into_string().unwrap();
+            let bytes = fs::read(path).unwrap();
+            group.bench_function(BenchmarkId::new("load", &name), move |b| {
+                let data = bytes.clone();
+                b.iter(|| {
+                    let tree = collapsed::load(black_box(data.as_slice())).unwrap();
+                    black_box(tree);
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_load_collapsed);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- execute all benches in CI
- document benchmark policy in AGENTS

## Testing
- `bash .agent/hooks/pre-push.sh` *(failed to finish in time)*
- `cargo bench --package flameview --no-run`

------
https://chatgpt.com/codex/tasks/task_e_688bf5c1b858832094de75ca23fd4eb4