### PR TITLE
Fix tests to compile under miri

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/crates/cli/tests/flamegraph.rs
+++ b/crates/cli/tests/flamegraph.rs
@@ -3,7 +3,6 @@
 use std::{fs, path::PathBuf, process::Command};
 
 #[test]
-#[cfg(not(miri))]
 fn cargo_flamegraph_saves_folded_stacks() {
     // locate fixture crate
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/cli/tests/flamegraph.rs
+++ b/crates/cli/tests/flamegraph.rs
@@ -1,4 +1,6 @@
-use std::{path::PathBuf, process::Command, fs};
+#![cfg(not(miri))]
+
+use std::{fs, path::PathBuf, process::Command};
 
 #[test]
 #[cfg(not(miri))]
@@ -17,18 +19,18 @@ fn cargo_flamegraph_saves_folded_stacks() {
 
     let mut cmd = Command::new("cargo");
     cmd.args([
-            "flamegraph",
-            "--manifest-path",
-            manifest.to_str().unwrap(),
-            "--bin",
-            "flamegraph-fixture",
-            "--freq",
-            "100",
-            "--output",
-            svg.to_str().unwrap(),
-            "--post-process",
-            &format!("tee {}", folded.to_string_lossy()),
-        ]);
+        "flamegraph",
+        "--manifest-path",
+        manifest.to_str().unwrap(),
+        "--bin",
+        "flamegraph-fixture",
+        "--freq",
+        "100",
+        "--output",
+        svg.to_str().unwrap(),
+        "--post-process",
+        &format!("tee {}", folded.to_string_lossy()),
+    ]);
 
     if let Ok(entries) = std::fs::read_dir("/usr/lib") {
         for e in entries.flatten() {


### PR DESCRIPTION
## Summary
- gate `flamegraph` CLI test for miri
- run fmt/clippy with `--cfg miri`

## Testing
- `cargo test --workspace --all-features --verbose`
- `RUSTFLAGS="--cfg miri" cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `actionlint -color`

------
https://chatgpt.com/codex/tasks/task_e_688c09d820b48320b8192204a13aad1f