### PR TITLE
setup: link generic linux-tools to running kernel

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -68,6 +68,16 @@ sudo apt-get install -y \
   linux-tools-common "linux-tools-$(uname -r)" || \
   sudo apt-get install -y linux-tools-generic
 
+# If the running kernel lacks a matching linux-tools package,
+# ensure the generic tools are accessible via the expected path
+TOOLS_DIR="/usr/lib/linux-tools/$(uname -r)"
+if [[ ! -d "$TOOLS_DIR" ]]; then
+  FALLBACK_DIR="$(ls -d /usr/lib/linux-tools/* 2>/dev/null | head -n1 || true)"
+  if [[ -n "$FALLBACK_DIR" && ! -e "$TOOLS_DIR" ]]; then
+    sudo ln -s "$FALLBACK_DIR" "$TOOLS_DIR"
+  fi
+fi
+
 sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-${CLANG_VERSION}   100
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid' || true

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -63,10 +63,9 @@ echo "deb [signed-by=/usr/share/keyrings/llvm.asc] \
 
 sudo apt-get update
 sudo apt-get install -y \
-  clang-${CLANG_VERSION} lldb-${CLANG_VERSION} lld-${CLANG_VERSION} \
-  llvm-${CLANG_VERSION}-dev \
-  linux-tools-common "linux-tools-$(uname -r)" || \
-  sudo apt-get install -y linux-tools-generic
+  clang-${CLANG_VERSION} lldb-${CLANG_VERSION} lld-${CLANG_VERSION} llvm-${CLANG_VERSION}-dev 
+sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" \
+  || sudo apt-get install -y linux-tools-generic
 
 # If the running kernel lacks a matching linux-tools package,
 # ensure the generic tools are accessible via the expected path


### PR DESCRIPTION
## Summary
- ensure perf is usable even when linux-tools for the running kernel isn't packaged by symlinking the generic tools to the kernel-specific path

## Testing
- `bash .agent/setup.sh`
- `perf --version`
- `bash .agent/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688da7cd75b88320adcca6ec5a790168