### PR TITLE
Reduce benchmark warmup and measurement time to 1s

### DIFF
--- a/crates/flameview/benches/add_one.rs
+++ b/crates/flameview/benches/add_one.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use flameview::add_one;
 
@@ -5,5 +7,11 @@ fn bench_add_one(c: &mut Criterion) {
     c.bench_function("add_one", |b| b.iter(|| add_one(black_box(41))));
 }
 
-criterion_group!(benches, bench_add_one);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
+    targets = bench_add_one
+}
 criterion_main!(benches);

--- a/crates/flameview/benches/load_collapsed.rs
+++ b/crates/flameview/benches/load_collapsed.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use flameview::loader::collapsed;
@@ -7,6 +8,8 @@ use flameview::loader::collapsed;
 fn bench_load_collapsed(c: &mut Criterion) {
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/data");
     let mut group = c.benchmark_group("load_collapsed");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(1));
     for entry in fs::read_dir(&data_dir).unwrap() {
         let entry = entry.unwrap();
         let path = entry.path();


### PR DESCRIPTION
## Summary
- shorten Criterion warm-up and measurement time to 1s for all benches

## Testing
- `AGENT_CHECK_MIRI_DISABLE=true bash .agent/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688db40fad7883208d3798b2d18302cf