### PR TITLE
feat: speed up local checks

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -30,14 +30,21 @@ and tips that help future contributors. Keep entries brief yet informative.
 - Aim for correctness before optimizations
 - Document style feedback here so it's not forgotten
 - Update this file whenever assumptions change or new tasks arise
+- When renaming or removing code, search (`rg old_name`) for references in
+  workflows, scripts, and docs to prevent stale CI configurations.
 
 This document is short-term memory. Run `bash .agent/setup.sh` once to install
 tools, then `bash .agent/check.sh` before pushing.
 
 ### Benchmarks
 - All benches live in `crates/flameview/benches/` and are executed in CI via
-  `cargo bench --package flameview`. Adding a new benchmark does not require
-  modifying workflow files.
+  `cargo bench --package flameview`.
+- The `flamegraph` workflow generates a flamegraph from the
+  `load_largest` bench. If a bench is renamed or removed, search for stale
+  references (e.g. `rg add_one`) and update `.github/workflows/flamegraph.yml`.
+- Before pushing bench changes, run `cargo bench --package flameview --no-run`
+  to ensure all targets compile and try the workflow command locally:
+  `cargo flamegraph --package flameview --bench load_largest -- --bench`.
 - For quick iterations, `cargo bench --package flameview --features bench-fast`
   runs a small subset of benches with shorter warmup and measurement times so
   the suite finishes in under 30 seconds.

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -41,6 +41,9 @@ tools, then `bash .agent/check.sh` before pushing.
 - For quick iterations, `cargo bench --package flameview --features bench-fast`
   runs a small subset of benches with shorter warmup and measurement times so
   the suite finishes in under 30 seconds.
+- For quick test runs, `cargo test --features test-fast` trims fixture sets and
+  lowers property-test iterations. `.agent/check.sh` enables this feature
+  automatically.
 
 ### Notes
 - Miri runs tests in an isolated environment without access to OS operations like opening directories. Any test that reads from the filesystem should either be skipped with `#[cfg(not(miri))]` or rewritten to avoid directory reads when running under Miri.

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -89,8 +89,8 @@ EXCLUDE_ARGS=(--exclude "$FUZZ_CRATE")
 
 cargo fetch
 cargo build  --workspace --release               "${EXCLUDE_ARGS[@]}"
-cargo test   --workspace --all-features --no-run  "${EXCLUDE_ARGS[@]}"
-cargo clippy --workspace --all-targets --all-features "${EXCLUDE_ARGS[@]}" -- -D warnings
+cargo test   --workspace --no-run               "${EXCLUDE_ARGS[@]}"
+cargo clippy --workspace --all-targets         "${EXCLUDE_ARGS[@]}" -- -D warnings
 
 # Optional fuzz pre-compile
 if [[ -d "$FUZZ_CRATE" ]]; then

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -23,7 +23,7 @@ jobs:
             sudo apt-get install -y linux-tools-generic
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
       - name: Generate flamegraph
-        run: cargo flamegraph --package flameview --bench add_one -- --bench
+        run: cargo flamegraph --package flameview --bench load_largest -- --bench
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Run clippy
-        run: cargo clippy --workspace --exclude flameview-fuzz --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --exclude flameview-fuzz --all-targets -- -D warnings
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run tests under Miri
         run: |
           cargo miri setup
-          cargo miri test --all-features --workspace
+          cargo miri test --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
             sudo apt-get install -y linux-tools-generic
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
       - name: Run test suite
-        run: cargo test --all --workspace --exclude flameview-fuzz --all-features --verbose
+        run: cargo test --all --workspace --exclude flameview-fuzz --verbose

--- a/crates/flameview/Cargo.toml
+++ b/crates/flameview/Cargo.toml
@@ -7,7 +7,11 @@ license = "MIT OR Apache-2.0"
 autobenches = false
 
 [features]
+# Optional speedups for tests and benchmarks. Coding agents enable
+# `bench-fast` and `test-fast` for quick feedback; CI omits them to run
+# exhaustive suites.
 bench-fast = []
+test-fast = []
 
 [dependencies]
 smallvec = "1"

--- a/crates/flameview/benches/load_largest.rs
+++ b/crates/flameview/benches/load_largest.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use flameview::loader::collapsed;
+use std::time::Duration;
 
 fn bench_load_largest(c: &mut Criterion) {
     let data = include_bytes!("../../../tests/data/perf-vertx-stacks-01-collapsed-all.txt");
@@ -11,5 +12,21 @@ fn bench_load_largest(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_load_largest);
+fn criterion() -> Criterion {
+    let mut c = Criterion::default();
+    if cfg!(feature = "bench-fast") {
+        c = c
+            .warm_up_time(Duration::from_millis(10))
+            .measurement_time(Duration::from_millis(100))
+            .sample_size(10);
+    }
+    c
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion();
+    targets = bench_load_largest
+}
+
 criterion_main!(benches);

--- a/crates/flameview/tests/collapsed_suite.rs
+++ b/crates/flameview/tests/collapsed_suite.rs
@@ -3,19 +3,32 @@ use std::fs;
 
 #[test]
 fn totals_match_fixture_names() {
-    for entry in fs::read_dir("../../tests/data").unwrap() {
-        let path = entry.unwrap().path();
-        if path.extension().and_then(|s| s.to_str()) == Some("txt") {
-            let data = fs::read(&path).unwrap();
-            let tree = flameview::loader::collapsed::load_slice(data.as_slice()).unwrap();
-            if let Some(num) = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .and_then(|s| s.rsplit('-').next())
-                .and_then(|s| s.parse::<u64>().ok())
-            {
-                assert_eq!(tree.total_samples(), num, "file {path:?}");
+    let mut paths: Vec<_> = fs::read_dir("../../tests/data")
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("txt") {
+                Some(path)
+            } else {
+                None
             }
+        })
+        .collect();
+
+    if cfg!(feature = "test-fast") {
+        paths.truncate(2);
+    }
+
+    for path in paths {
+        let data = fs::read(&path).unwrap();
+        let tree = flameview::loader::collapsed::load_slice(data.as_slice()).unwrap();
+        if let Some(num) = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.rsplit('-').next())
+            .and_then(|s| s.parse::<u64>().ok())
+        {
+            assert_eq!(tree.total_samples(), num, "file {path:?}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- speed up local build and test steps by enabling bench-fast and test-fast features in the check script
- trim fixture iteration when test-fast is enabled and expose fast benchmark mode
- drop `--all-features` from setup and CI workflows

## Testing
- `bash .agent/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688de4c5dd608320a8092cb92397ef8e