### PR TITLE
Add shared CLI opts and mock command executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,16 +219,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -559,6 +559,8 @@ dependencies = [
  "clap",
  "flameview",
  "insta",
+ "libc",
+ "serde_json",
  "tempfile",
  "which",
 ]
@@ -1427,31 +1429,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,13 +7,15 @@ edition = "2021"
 flameview = { path = "../flameview" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
-cargo_metadata = "0.18"
+cargo_metadata = "0.19"
 
 [dev-dependencies]
 insta = "1"
 tempfile = "3"
 which = "4"
 assert_cmd = "2"
+libc = "0.2"
+serde_json = "1"
 
 [[bin]]
 name = "flameview"

--- a/crates/cli/src/bin/cargo-flameview.rs
+++ b/crates/cli/src/bin/cargo-flameview.rs
@@ -25,6 +25,6 @@ fn main() -> anyhow::Result<()> {
         .map(|s| s.to_string_lossy())
         .collect::<Vec<_>>()
         .join(" ");
-    println!("{}", display);
+    println!("{display}");
     Ok(())
 }

--- a/crates/cli/src/bin/cargo-flameview.rs
+++ b/crates/cli/src/bin/cargo-flameview.rs
@@ -1,50 +1,30 @@
-use clap::{Parser, ValueEnum};
-use std::path::PathBuf;
+#[path = "../build.rs"]
+mod build;
+#[path = "../cli/opts.rs"]
+mod opts;
 
-#[derive(Parser, Debug)]
-#[command(author, version, about)]
-struct Opt {
-    #[arg(long)]
-    dev: bool,
-    #[arg(long)]
-    profile: Option<String>,
-    #[arg(long)]
-    package: Option<String>,
-    #[arg(long)]
-    bin: Option<String>,
-    #[arg(long)]
-    example: Option<String>,
-    #[arg(long)]
-    test: Option<String>,
-    #[arg(long)]
-    bench: Option<String>,
-    #[arg(long, value_name = "NAME", num_args = 0..=1)]
-    unit_test: Option<Option<String>>,
-    #[arg(long, value_name = "NAME", num_args = 0..=1)]
-    unit_bench: Option<Option<String>>,
-    #[arg(long, value_enum)]
-    unit_test_kind: Option<UnitTestTargetKind>,
-    #[arg(long)]
-    manifest_path: Option<PathBuf>,
-    #[arg(long)]
-    target: Option<String>,
-    #[arg(long)]
-    features: Option<String>,
-    #[arg(long)]
-    no_default_features: bool,
-    #[arg(long)]
-    release: bool,
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    trailing_arguments: Vec<String>,
-}
+use clap::Parser;
+use opts::{Opt, TargetKind};
 
-#[derive(ValueEnum, Clone, Debug)]
-enum UnitTestTargetKind {
-    Bin,
-    Lib,
-}
-
-fn main() {
+fn main() -> anyhow::Result<()> {
     let opt = Opt::parse();
-    println!("{opt:#?}");
+    let kinds = if opt.example.is_some() {
+        vec![TargetKind::Example]
+    } else if opt.test.is_some() || opt.unit_test.is_some() {
+        vec![TargetKind::Test]
+    } else if opt.bench.is_some() || opt.unit_bench.is_some() {
+        vec![TargetKind::Bench]
+    } else {
+        vec![TargetKind::Bin, TargetKind::Example]
+    };
+    let exec = build::RealCommandExecutor;
+    let artifacts = build::build(&exec, &opt, kinds)?;
+    let cmd = build::workload(&opt, &artifacts)?;
+    let display = cmd
+        .iter()
+        .map(|s| s.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+    println!("{}", display);
+    Ok(())
 }

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -1,0 +1,281 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use anyhow::{anyhow, Context};
+use cargo_metadata::{Message, MetadataCommand};
+
+pub use cargo_metadata::{Artifact, ArtifactDebuginfo};
+
+use crate::opts::{Opt, TargetKind};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct BinaryTarget {
+    pub package: String,
+    pub target: String,
+    pub kind: Vec<TargetKind>,
+}
+
+#[allow(dead_code)]
+pub trait CommandExecutor {
+    fn run(&self, cmd: &mut Command) -> io::Result<Output>;
+}
+
+pub struct RealCommandExecutor;
+
+impl CommandExecutor for RealCommandExecutor {
+    fn run(&self, cmd: &mut Command) -> io::Result<Output> {
+        cmd.output()
+    }
+}
+
+pub fn find_crate_root(manifest_path: Option<&Path>) -> anyhow::Result<PathBuf> {
+    if let Some(mp) = manifest_path {
+        let dir = mp
+            .parent()
+            .ok_or_else(|| anyhow!("invalid manifest path"))?;
+        return std::fs::canonicalize(dir).context("canonicalize manifest dir");
+    }
+    let mut dir = std::env::current_dir().context("current dir")?;
+    loop {
+        if dir.join("Cargo.toml").is_file() {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    Err(anyhow!("could not find Cargo.toml"))
+}
+
+pub fn find_unique_target(
+    kind: &[TargetKind],
+    pkg: Option<&str>,
+    manifest_path: Option<&Path>,
+    target_name: Option<&str>,
+) -> anyhow::Result<BinaryTarget> {
+    let mut cmd = MetadataCommand::new();
+    cmd.no_deps();
+    if let Some(mp) = manifest_path {
+        cmd.manifest_path(mp);
+    }
+    let metadata = cmd.exec().context("metadata")?;
+
+    let crate_root = find_crate_root(manifest_path)?;
+    let packages = metadata.packages.into_iter().filter(|p| {
+        if let Some(name) = pkg {
+            p.name == name
+        } else {
+            p.manifest_path
+                .as_std_path()
+                .parent()
+                .map(|d| d == crate_root)
+                .unwrap_or(false)
+        }
+    });
+
+    let mut candidates = Vec::new();
+    let mut defaults = Vec::new();
+    for p in packages {
+        for t in &p.targets {
+            if t.kind.iter().any(|k| kind.contains(k)) {
+                let bt = BinaryTarget {
+                    package: p.name.clone(),
+                    target: t.name.clone(),
+                    kind: t.kind.clone(),
+                };
+                if let Some(def) = &p.default_run {
+                    if def == &t.name {
+                        defaults.push(bt.clone());
+                    }
+                }
+                candidates.push(bt);
+            }
+        }
+    }
+
+    let mut list = if let Some(name) = target_name {
+        candidates
+            .into_iter()
+            .filter(|t| t.target == name)
+            .collect::<Vec<_>>()
+    } else if defaults.len() == 1 {
+        defaults
+    } else {
+        candidates
+    };
+
+    if list.len() == 1 {
+        Ok(list.remove(0))
+    } else if list.is_empty() {
+        Err(anyhow!("no targets found for kinds {:?}", kind))
+    } else {
+        let names: Vec<_> = list.iter().map(|t| t.target.clone()).collect();
+        Err(anyhow!("multiple targets match: {}", names.join(", ")))
+    }
+}
+
+#[allow(dead_code)]
+pub fn build(
+    exec: &dyn CommandExecutor,
+    opt: &Opt,
+    kind: Vec<TargetKind>,
+) -> anyhow::Result<Vec<Artifact>> {
+    let mut cmd = Command::new("cargo");
+    if !opt.dev && (opt.bench.is_some() || opt.unit_bench.is_some()) {
+        cmd.args(["bench", "--no-run"]);
+    } else if opt.unit_test.is_some() {
+        cmd.args(["test", "--no-run"]);
+    } else {
+        cmd.arg("build");
+    }
+    if let Some(profile) = &opt.profile {
+        cmd.args(["--profile", profile]);
+    } else if opt.release {
+        cmd.arg("--release");
+    }
+    if let Some(pkg) = &opt.package {
+        cmd.args(["--package", pkg]);
+    }
+    let mut specified = false;
+    if let Some(bin) = &opt.bin {
+        cmd.args(["--bin", bin]);
+        specified = true;
+    }
+    if let Some(example) = &opt.example {
+        cmd.args(["--example", example]);
+        specified = true;
+    }
+    if let Some(test) = &opt.test {
+        cmd.args(["--test", test]);
+        specified = true;
+    }
+    if let Some(bench) = &opt.bench {
+        cmd.args(["--bench", bench]);
+        specified = true;
+    }
+    if let Some(unit_test) = &opt.unit_test {
+        specified = true;
+        if let Some(name) = unit_test {
+            cmd.args(["--test", name]);
+        } else {
+            cmd.arg("--tests");
+        }
+    }
+    if let Some(unit_bench) = &opt.unit_bench {
+        specified = true;
+        if let Some(name) = unit_bench {
+            cmd.args(["--bench", name]);
+        } else {
+            cmd.arg("--benches");
+        }
+    }
+    if !specified && !kind.is_empty() {
+        let bt = find_unique_target(
+            &kind,
+            opt.package.as_deref(),
+            opt.manifest_path.as_deref(),
+            None,
+        )?;
+        cmd.args(["--package", &bt.package]);
+        if bt.kind.contains(&TargetKind::Bin) {
+            cmd.args(["--bin", &bt.target]);
+        } else if bt.kind.contains(&TargetKind::Example) {
+            cmd.args(["--example", &bt.target]);
+        } else if bt.kind.contains(&TargetKind::Test) {
+            cmd.args(["--test", &bt.target]);
+        } else if bt.kind.contains(&TargetKind::Bench) {
+            cmd.args(["--bench", &bt.target]);
+        } else {
+            return Err(anyhow!("unknown target kind {:?}", bt.kind));
+        }
+    }
+    if let Some(manifest) = &opt.manifest_path {
+        cmd.args(["--manifest-path", manifest.to_str().unwrap()]);
+    }
+    if let Some(target) = &opt.target {
+        cmd.args(["--target", target]);
+    }
+    if let Some(features) = &opt.features {
+        cmd.args(["--features", features]);
+    }
+    if opt.no_default_features {
+        cmd.arg("--no-default-features");
+    }
+    cmd.arg("--message-format=json-render-diagnostics");
+    cmd.stderr(Stdio::inherit());
+    let Output { status, stdout, .. } = exec.run(&mut cmd).map_err(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            anyhow!("failed to execute `cargo`: not found in PATH")
+        } else {
+            anyhow!("failed to execute `cargo`: {e}")
+        }
+    })?;
+    if !status.success() {
+        return Err(anyhow!("cargo build failed"));
+    }
+    let mut artifacts = Vec::new();
+    for message in Message::parse_stream(stdout.as_slice()).flatten() {
+        if let Message::CompilerArtifact(artifact) = message {
+            artifacts.push(artifact);
+        }
+    }
+    Ok(artifacts)
+}
+
+pub type Workload = Vec<std::ffi::OsString>;
+
+pub fn workload(opt: &Opt, artifacts: &[Artifact]) -> anyhow::Result<Workload> {
+    if !artifacts.iter().any(|a| a.executable.is_some()) {
+        return Err(anyhow!("no executable artifacts"));
+    }
+    let mut cmd: Workload = Vec::new();
+    let (name, kind) = if let Some(bin) = &opt.bin {
+        (bin.clone(), TargetKind::Bin)
+    } else if let Some(example) = &opt.example {
+        (example.clone(), TargetKind::Example)
+    } else if let Some(test) = &opt.test {
+        (test.clone(), TargetKind::Test)
+    } else if let Some(bench) = &opt.bench {
+        (bench.clone(), TargetKind::Bench)
+    } else {
+        let bt = find_unique_target(
+            &[
+                TargetKind::Bin,
+                TargetKind::Example,
+                TargetKind::Test,
+                TargetKind::Bench,
+            ],
+            opt.package.as_deref(),
+            opt.manifest_path.as_deref(),
+            None,
+        )?;
+        let k = bt
+            .kind
+            .iter()
+            .find(|k| {
+                matches!(
+                    k,
+                    TargetKind::Bin | TargetKind::Example | TargetKind::Test | TargetKind::Bench
+                )
+            })
+            .cloned()
+            .ok_or_else(|| anyhow!("unknown target kind {:?}", bt.kind))?;
+        (bt.target, k)
+    };
+    let artifact = artifacts
+        .iter()
+        .find(|a| a.target.name == name && a.target.kind.contains(&kind))
+        .ok_or_else(|| anyhow!("target artifact not found"))?;
+    let exe = artifact
+        .executable
+        .as_ref()
+        .ok_or_else(|| anyhow!("selected artifact has no executable"))?;
+    if !opt.dev && artifact.profile.debuginfo == ArtifactDebuginfo::None {
+        eprintln!("warning: selected profile lacks debuginfo");
+    }
+    cmd.push(exe.clone().into_std_path_buf().into_os_string());
+    cmd.extend(opt.trailing_arguments.iter().cloned().map(Into::into));
+    Ok(cmd)
+}

--- a/crates/cli/src/cli/opts.rs
+++ b/crates/cli/src/cli/opts.rs
@@ -1,0 +1,46 @@
+pub use cargo_metadata::TargetKind;
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about)]
+pub struct Opt {
+    #[arg(long)]
+    pub dev: bool,
+    #[arg(long)]
+    pub profile: Option<String>,
+    #[arg(long)]
+    pub package: Option<String>,
+    #[arg(long)]
+    pub bin: Option<String>,
+    #[arg(long)]
+    pub example: Option<String>,
+    #[arg(long)]
+    pub test: Option<String>,
+    #[arg(long)]
+    pub bench: Option<String>,
+    #[arg(long, value_name = "NAME", num_args = 0..=1)]
+    pub unit_test: Option<Option<String>>,
+    #[arg(long, value_name = "NAME", num_args = 0..=1)]
+    pub unit_bench: Option<Option<String>>,
+    #[arg(long, value_enum)]
+    pub unit_test_kind: Option<UnitTestTargetKind>,
+    #[arg(long)]
+    pub manifest_path: Option<PathBuf>,
+    #[arg(long)]
+    pub target: Option<String>,
+    #[arg(long)]
+    pub features: Option<String>,
+    #[arg(long)]
+    pub no_default_features: bool,
+    #[arg(long)]
+    pub release: bool,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub trailing_arguments: Vec<String>,
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum UnitTestTargetKind {
+    Bin,
+    Lib,
+}

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -1,0 +1,212 @@
+#![cfg(not(miri))]
+
+use assert_cmd::prelude::*;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[path = "../src/build.rs"]
+mod build;
+#[path = "support/mock_exec.rs"]
+mod mock_exec;
+#[path = "../src/cli/opts.rs"]
+mod opts;
+use build::{find_crate_root, find_unique_target, workload, Artifact};
+use mock_exec::{success, MockCommandExecutor};
+use opts::{Opt, TargetKind};
+use std::fs;
+use tempfile::tempdir;
+
+fn artifact_example(path: &str) -> Artifact {
+    serde_json::from_value(serde_json::json!({
+        "package_id": "pkg",
+        "manifest_path": "",
+        "target": {
+            "name": "eg",
+            "kind": ["bin"],
+            "crate_types": [],
+            "required-features": [],
+            "src_path": "src/main.rs",
+            "edition": "2021",
+            "doctest": true,
+            "test": true,
+            "doc": true
+        },
+        "profile": {
+            "opt_level": "0",
+            "debuginfo": 0,
+            "debug_assertions": true,
+            "overflow_checks": true,
+            "test": false
+        },
+        "features": [],
+        "filenames": [],
+        "executable": path,
+        "fresh": true
+    }))
+    .unwrap()
+}
+
+#[test]
+fn find_crate_root_finds_manifest() {
+    let tmp = tempdir().unwrap();
+    fs::write(tmp.path().join("Cargo.toml"), "").unwrap();
+    let nested = tmp.path().join("a/b");
+    fs::create_dir_all(&nested).unwrap();
+    let old = std::env::current_dir().unwrap();
+    std::env::set_current_dir(&nested).unwrap();
+    let root = find_crate_root(None).unwrap();
+    assert_eq!(root, tmp.path().canonicalize().unwrap());
+    std::env::set_current_dir(old).unwrap();
+}
+
+#[test]
+fn find_unique_target_errors_on_ambiguous() {
+    let tmp = tempdir().unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        r#"[package]
+name="double"
+version="0.1.0"
+edition="2021"
+[[bin]]
+name="one"
+path="one.rs"
+[[bin]]
+name="two"
+path="two.rs"
+"#,
+    )
+    .unwrap();
+    fs::write(tmp.path().join("one.rs"), "fn main() {}").unwrap();
+    fs::write(tmp.path().join("two.rs"), "fn main() {}").unwrap();
+    let manifest = tmp.path().join("Cargo.toml");
+    let err =
+        find_unique_target(&[TargetKind::Bin], None, Some(manifest.as_path()), None).unwrap_err();
+    assert!(err.to_string().contains("multiple targets"));
+}
+
+#[test]
+fn workload_warns_without_debuginfo() {
+    let opt = Opt {
+        dev: false,
+        profile: None,
+        package: None,
+        bin: Some("eg".into()),
+        example: None,
+        test: None,
+        bench: None,
+        unit_test: None,
+        unit_bench: None,
+        unit_test_kind: None,
+        manifest_path: None,
+        target: None,
+        features: None,
+        no_default_features: false,
+        release: false,
+        trailing_arguments: vec![],
+    };
+    let art = artifact_example("/tmp/eg");
+    let warning = capture_stderr(|| {
+        workload(&opt, &[art]).unwrap();
+    });
+    assert!(warning.contains("debuginfo"));
+}
+
+fn capture_stderr<F: FnOnce()>(f: F) -> String {
+    use std::io::Read;
+    use std::os::unix::io::FromRawFd;
+    unsafe {
+        let mut fds = [0; 2];
+        libc::pipe(fds.as_mut_ptr());
+        let stderr_fd = libc::STDERR_FILENO;
+        let saved = libc::dup(stderr_fd);
+        libc::dup2(fds[1], stderr_fd);
+        libc::close(fds[1]);
+        f();
+        libc::fflush(std::ptr::null_mut());
+        let mut file = std::fs::File::from_raw_fd(fds[0]);
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        libc::dup2(saved, stderr_fd);
+        libc::close(saved);
+        String::from_utf8(buf).unwrap()
+    }
+}
+
+#[test]
+fn build_and_select_example_binary() {
+    let crate_dir: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "tests",
+        "fixtures",
+        "simple-example",
+    ]
+    .iter()
+    .collect();
+    let manifest_cli: PathBuf = [env!("CARGO_MANIFEST_DIR"), "Cargo.toml"].iter().collect();
+    let assert = Command::new("cargo")
+        .current_dir(&crate_dir)
+        .args([
+            "run",
+            "--manifest-path",
+            manifest_cli.to_str().unwrap(),
+            "--bin",
+            "cargo-flameview",
+            "--",
+            "--example",
+            "eg",
+            "--",
+            "--help",
+        ])
+        .assert()
+        .success();
+    let out = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let line = out.lines().next().unwrap();
+    assert!(line.ends_with("target/debug/examples/eg --help"));
+}
+
+#[test]
+fn build_uses_mock_executor() {
+    use cargo_metadata::Message;
+    use std::process::Output;
+
+    let artifact = artifact_example("/tmp/eg");
+    let msg = Message::CompilerArtifact(artifact.clone());
+    let mut stdout = serde_json::to_vec(&msg).unwrap();
+    stdout.push(b'\n');
+    let output = Output {
+        status: success(),
+        stdout,
+        stderr: Vec::new(),
+    };
+    let expected = vec![vec![
+        "cargo".into(),
+        "build".into(),
+        "--bin".into(),
+        "eg".into(),
+        "--message-format=json-render-diagnostics".into(),
+    ]];
+    let script = expected.into_iter().zip(std::iter::once(output)).collect();
+    let exec = MockCommandExecutor::new(script);
+    let opt = Opt {
+        dev: false,
+        profile: None,
+        package: None,
+        bin: Some("eg".into()),
+        example: None,
+        test: None,
+        bench: None,
+        unit_test: None,
+        unit_bench: None,
+        unit_test_kind: None,
+        manifest_path: None,
+        target: None,
+        features: None,
+        no_default_features: false,
+        release: false,
+        trailing_arguments: vec![],
+    };
+    let artifacts = build::build(&exec, &opt, vec![TargetKind::Bin]).unwrap();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].target.name, "eg");
+}

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -48,5 +48,10 @@ fn parse_trailing_arguments() {
         .assert()
         .success();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
-    assert!(stdout.contains("trailing_arguments: [\n        \"foo\",\n        \"bar\",\n    ],"));
+    let trailing = stdout
+        .split_whitespace()
+        .skip(1)
+        .collect::<Vec<_>>()
+        .join(" ");
+    insta::assert_snapshot!(trailing, @"foo bar");
 }

--- a/crates/cli/tests/fixtures/simple-example/Cargo.toml
+++ b/crates/cli/tests/fixtures/simple-example/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "simple-example"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]

--- a/crates/cli/tests/fixtures/simple-example/examples/eg.rs
+++ b/crates/cli/tests/fixtures/simple-example/examples/eg.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello");
+}

--- a/crates/cli/tests/support/mock_exec.rs
+++ b/crates/cli/tests/support/mock_exec.rs
@@ -1,0 +1,44 @@
+use std::cell::RefCell;
+use std::io;
+use std::process::{Command, Output};
+
+use crate::build::CommandExecutor;
+
+pub struct MockCommandExecutor {
+    script: RefCell<Vec<(Vec<String>, Output)>>,
+}
+
+impl MockCommandExecutor {
+    pub fn new(script: Vec<(Vec<String>, Output)>) -> Self {
+        Self {
+            script: RefCell::new(script),
+        }
+    }
+}
+
+impl CommandExecutor for MockCommandExecutor {
+    fn run(&self, cmd: &mut Command) -> io::Result<Output> {
+        let args = std::iter::once(cmd.get_program().to_string_lossy().into_owned())
+            .chain(cmd.get_args().map(|a| a.to_string_lossy().into_owned()))
+            .collect::<Vec<_>>();
+        let mut script = self.script.borrow_mut();
+        if script.is_empty() {
+            return Err(io::Error::other("unexpected command"));
+        }
+        let (expect, output) = script.remove(0);
+        assert_eq!(expect, args, "command arguments mismatch");
+        Ok(output)
+    }
+}
+
+#[cfg(unix)]
+pub fn success() -> std::process::ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    std::process::ExitStatus::from_raw(0)
+}
+
+#[cfg(windows)]
+pub fn success() -> std::process::ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    std::process::ExitStatus::from_raw(0)
+}


### PR DESCRIPTION
## Summary
- centralize CLI options and leverage `cargo_metadata::TargetKind`
- surface clearer build errors and return workload as `Vec<OsString>`
- add mockable command executor and restore trailing-argument test

## Testing
- `cargo test --workspace --all-features --exclude flameview-fuzz`
- `cargo clippy -p flameview-cli --all-targets --all-features -- -D warnings`
- `bash .agent/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ddf9a1a10832086ba1cca29d3ed09