### PR TITLE
feat(cli): profile workloads with perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -111,6 +112,12 @@ name = "arbitrary-int"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
@@ -417,6 +424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +462,20 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "difflib"
@@ -484,6 +514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +530,16 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -558,6 +607,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "flameview",
+ "inferno",
  "insta",
  "libc",
  "serde_json",
@@ -679,6 +729,29 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger 0.11.8",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
 ]
 
 [[package]]
@@ -941,6 +1014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,12 +1180,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.4",
  "log",
  "rand",
 ]
@@ -1197,6 +1289,15 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "roxmltree"
@@ -1390,6 +1491,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "strsim"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,8 @@ flameview = { path = "../flameview" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 cargo_metadata = "0.19"
+inferno = "0.11"
+tempfile = "3"
 
 [dev-dependencies]
 insta = "1"

--- a/crates/cli/src/bin/cargo-flameview.rs
+++ b/crates/cli/src/bin/cargo-flameview.rs
@@ -2,6 +2,8 @@
 mod build;
 #[path = "../cli/opts.rs"]
 mod opts;
+#[path = "../profile.rs"]
+mod profile;
 
 use clap::Parser;
 use opts::{Opt, TargetKind};
@@ -20,11 +22,13 @@ fn main() -> anyhow::Result<()> {
     let exec = build::RealCommandExecutor;
     let artifacts = build::build(&exec, &opt, kinds)?;
     let cmd = build::workload(&opt, &artifacts)?;
-    let display = cmd
+    let workload = cmd
         .iter()
-        .map(|s| s.to_string_lossy())
-        .collect::<Vec<_>>()
-        .join(" ");
+        .map(|s| s.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let display = workload.join(" ");
     println!("{display}");
+    let result = profile::profile(&exec, &workload, &opt)?;
+    println!("folded: {}", result.folded_path.display());
     Ok(())
 }

--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -130,7 +130,7 @@ pub fn build(
     } else {
         cmd.arg("build");
     }
-    if let Some(profile) = &opt.profile {
+    if let Some(profile) = &opt.cargo_profile {
         cmd.args(["--profile", profile]);
     } else if opt.release {
         cmd.arg("--release");

--- a/crates/cli/src/cli/opts.rs
+++ b/crates/cli/src/cli/opts.rs
@@ -1,3 +1,4 @@
+use crate::profile::ProfileOptions;
 pub use cargo_metadata::TargetKind;
 use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
@@ -8,7 +9,8 @@ pub struct Opt {
     #[arg(long)]
     pub dev: bool,
     #[arg(long)]
-    pub profile: Option<String>,
+    #[arg(long = "profile")]
+    pub cargo_profile: Option<String>,
     #[arg(long)]
     pub package: Option<String>,
     #[arg(long)]
@@ -35,6 +37,8 @@ pub struct Opt {
     pub no_default_features: bool,
     #[arg(long)]
     pub release: bool,
+    #[clap(flatten)]
+    pub profile: ProfileOptions,
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub trailing_arguments: Vec<String>,
 }

--- a/crates/cli/src/profile.rs
+++ b/crates/cli/src/profile.rs
@@ -1,0 +1,124 @@
+use anyhow::{anyhow, Context};
+use clap::Args;
+use inferno::collapse::perf::{Folder, Options as PerfOptions};
+use inferno::collapse::Collapse;
+use std::fs::{self, File};
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tempfile::Builder;
+
+use crate::build::{find_crate_root, CommandExecutor};
+use crate::opts::Opt;
+
+#[derive(Args, Debug, Clone)]
+pub struct ProfileOptions {
+    #[clap(long, default_value_t = 99)]
+    pub frequency: u32,
+    #[clap(long)]
+    pub output: Option<PathBuf>,
+    #[clap(long)]
+    pub keep_perf_data: bool,
+    #[clap(long, value_name = "CMD")]
+    pub cmd: Option<String>,
+}
+
+pub struct ProfileResult {
+    pub folded_path: PathBuf,
+}
+
+fn profile_name(opt: &Opt) -> &str {
+    if let Some(p) = &opt.cargo_profile {
+        p
+    } else if opt.release {
+        "release"
+    } else {
+        "debug"
+    }
+}
+
+pub fn profile(
+    exec: &dyn CommandExecutor,
+    workload: &[String],
+    opt: &Opt,
+) -> anyhow::Result<ProfileResult> {
+    if workload.is_empty() {
+        return Err(anyhow!("empty workload"));
+    }
+
+    let temp = Builder::new().prefix("perf.data").tempfile()?;
+    let perf_path = temp.into_temp_path();
+
+    let crate_root = find_crate_root(opt.manifest_path.as_deref())?;
+    let profile_name = profile_name(opt);
+    let target_name = Path::new(&workload[0])
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow!("invalid workload path"))?;
+    let folded_path = if let Some(out) = &opt.profile.output {
+        out.clone()
+    } else {
+        crate_root
+            .join("target")
+            .join("flameview")
+            .join(profile_name)
+            .join(format!("{}.folded", target_name))
+    };
+
+    if let Some(parent) = folded_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let perf_cmd = opt.profile.cmd.clone().unwrap_or_else(|| {
+        format!(
+            "record -F {} --call-graph dwarf,64000 -g",
+            opt.profile.frequency
+        )
+    });
+    let mut cmd = Command::new("perf");
+    for token in perf_cmd.split_whitespace() {
+        cmd.arg(token);
+    }
+    cmd.arg("-o").arg(perf_path.as_os_str());
+    cmd.arg("--");
+    for w in workload {
+        cmd.arg(w);
+    }
+    cmd.stderr(Stdio::inherit());
+    let output = exec.run(&mut cmd).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow!("failed to execute `perf`: not found in PATH")
+        } else {
+            anyhow!("failed to execute `perf`: {e}")
+        }
+    })?;
+    if !output.status.success() {
+        return Err(anyhow!("perf record failed"));
+    }
+
+    let mut script = Command::new("perf");
+    script.args(["script", "--force", "-i"]);
+    script.arg(perf_path.as_os_str());
+    script.stderr(Stdio::inherit());
+    let output = exec.run(&mut script).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow!("failed to execute `perf script`: not found in PATH")
+        } else {
+            anyhow!("failed to execute `perf script`: {e}")
+        }
+    })?;
+    if !output.status.success() {
+        return Err(anyhow!("perf script failed"));
+    }
+
+    let collapse_opts = PerfOptions::default();
+    let mut folder = Folder::from(collapse_opts);
+    let folded_file = File::create(&folded_path).context("create folded file")?;
+    folder.collapse(output.stdout.as_slice(), BufWriter::new(folded_file))?;
+
+    if opt.profile.keep_perf_data {
+        perf_path.keep()?;
+    }
+
+    Ok(ProfileResult { folded_path })
+}

--- a/crates/cli/tests/build.rs
+++ b/crates/cli/tests/build.rs
@@ -11,6 +11,9 @@ mod build;
 mod mock_exec;
 #[path = "../src/cli/opts.rs"]
 mod opts;
+#[allow(dead_code)]
+#[path = "../src/profile.rs"]
+mod profile;
 use build::{find_crate_root, find_unique_target, Artifact};
 use mock_exec::{success, MockCommandExecutor};
 use opts::{Opt, TargetKind};
@@ -175,7 +178,7 @@ fn build_uses_mock_executor() {
     let exec = MockCommandExecutor::new(script);
     let opt = Opt {
         dev: false,
-        profile: None,
+        cargo_profile: None,
         package: None,
         bin: Some("eg".into()),
         example: None,
@@ -189,6 +192,12 @@ fn build_uses_mock_executor() {
         features: None,
         no_default_features: false,
         release: false,
+        profile: profile::ProfileOptions {
+            frequency: 99,
+            output: None,
+            keep_perf_data: false,
+            cmd: None,
+        },
         trailing_arguments: vec![],
     };
     let artifacts = build::build(&exec, &opt, vec![TargetKind::Bin]).unwrap();

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -23,7 +23,7 @@ Arguments:
 
 Options:
       --dev
-      --profile <PROFILE>
+      --profile <CARGO_PROFILE>
       --package <PACKAGE>
       --bin <BIN>
       --example <EXAMPLE>
@@ -37,6 +37,10 @@ Options:
       --features <FEATURES>
       --no-default-features
       --release
+      --frequency <FREQUENCY>            [default: 99]
+      --output <OUTPUT>
+      --keep-perf-data
+      --cmd <CMD>
   -h, --help                             Print help
   -V, --version                          Print version
 "###);
@@ -69,7 +73,8 @@ fn parse_trailing_arguments() {
         .assert()
         .success();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
-    let trailing = stdout
+    let line = stdout.lines().next().unwrap();
+    let trailing = line
         .split_whitespace()
         .skip(1)
         .collect::<Vec<_>>()

--- a/crates/cli/tests/profile.rs
+++ b/crates/cli/tests/profile.rs
@@ -1,0 +1,131 @@
+#![cfg(not(miri))]
+
+use assert_cmd::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+#[allow(dead_code)]
+#[path = "../src/build.rs"]
+mod build;
+#[path = "../src/cli/opts.rs"]
+mod opts;
+#[allow(dead_code)]
+#[path = "../src/profile.rs"]
+mod profile;
+
+use build::CommandExecutor;
+use opts::Opt;
+use profile::{profile, ProfileOptions};
+
+struct MockPerf;
+
+impl CommandExecutor for MockPerf {
+    fn run(&self, cmd: &mut Command) -> std::io::Result<Output> {
+        let program = cmd.get_program().to_string_lossy().into_owned();
+        let args = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        if program == "perf" && args.first().map(|s| s.as_str()) == Some("record") {
+            assert_eq!(args.last().unwrap(), "/bin/true");
+            Ok(Output {
+                status: mock_exec::success(),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        } else if program == "perf" && args.first().map(|s| s.as_str()) == Some("script") {
+            Ok(Output {
+                status: mock_exec::success(),
+                stdout: b"foo 1/1 0: cpu-clock:\n    0 main (foo)\n\n".to_vec(),
+                stderr: Vec::new(),
+            })
+        } else {
+            panic!("unexpected command: {} {:?}", program, args);
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[path = "support/mock_exec.rs"]
+mod mock_exec;
+
+fn default_opt() -> Opt {
+    Opt {
+        dev: false,
+        cargo_profile: None,
+        package: None,
+        bin: None,
+        example: None,
+        test: None,
+        bench: None,
+        unit_test: None,
+        unit_bench: None,
+        unit_test_kind: None,
+        manifest_path: None,
+        target: None,
+        features: None,
+        no_default_features: false,
+        release: false,
+        profile: ProfileOptions {
+            frequency: 99,
+            output: None,
+            keep_perf_data: false,
+            cmd: None,
+        },
+        trailing_arguments: vec![],
+    }
+}
+
+#[test]
+fn profile_creates_folded_file() {
+    let exec = MockPerf;
+    let opt = default_opt();
+    let result = profile(&exec, &["/bin/true".into()], &opt).unwrap();
+    let data = fs::read_to_string(&result.folded_path).unwrap();
+    assert!(!data.is_empty());
+}
+
+#[test]
+fn profile_respects_output_override() {
+    let exec = MockPerf;
+    let mut opt = default_opt();
+    let dir = tempfile::tempdir().unwrap();
+    let custom = dir.path().join("custom.folded");
+    opt.profile.output = Some(custom.clone());
+    let result = profile(&exec, &["/bin/true".into()], &opt).unwrap();
+    assert_eq!(result.folded_path, custom);
+}
+
+#[test]
+fn run_profile_on_fixture() {
+    let crate_dir: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "tests",
+        "fixtures",
+        "simple-example",
+    ]
+    .iter()
+    .collect();
+    let manifest_cli: PathBuf = [env!("CARGO_MANIFEST_DIR"), "Cargo.toml"].iter().collect();
+    Command::new("cargo")
+        .current_dir(&crate_dir)
+        .args([
+            "run",
+            "--manifest-path",
+            manifest_cli.to_str().unwrap(),
+            "--bin",
+            "cargo-flameview",
+            "--",
+            "--example",
+            "eg",
+        ])
+        .assert()
+        .success();
+    let folded = crate_dir
+        .join("target")
+        .join("flameview")
+        .join("debug")
+        .join("eg.folded");
+    assert!(folded.is_file());
+}


### PR DESCRIPTION
## Summary
- add CLI profile options and perf-based profiler
- stream `perf script` output through inferno to create folded stacks
- test folded stack generation and output override

## Testing
- `bash .agent/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688ebe0c52c0832096450f28b474d679