### PR TITLE
Use format string capture for folded path

### DIFF
--- a/crates/cli/src/profile.rs
+++ b/crates/cli/src/profile.rs
@@ -62,7 +62,7 @@ pub fn profile(
             .join("target")
             .join("flameview")
             .join(profile_name)
-            .join(format!("{}.folded", target_name))
+            .join(format!("{target_name}.folded"))
     };
 
     if let Some(parent) = folded_path.parent() {


### PR DESCRIPTION
## Summary
- use captured variable format string for folded output path to satisfy clippy

## Testing
- `bash .agent/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688fe5a189a483208ccf961c89689cad