### PR TITLE
feat(cli): add sparkline tree view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,6 @@ dependencies = [
  "regex",
  "serde_json",
  "tempfile",
- "tui-tree-widget",
  "which",
 ]
 
@@ -1854,16 +1853,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "tui-tree-widget"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14c4488e071617f5b5922222193cdf6725835e492c6229557af85d3c1a4e903"
-dependencies = [
- "ratatui",
- "unicode-width 0.2.0",
-]
 
 [[package]]
 name = "tuple_list"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,7 +11,6 @@ cargo_metadata = "0.19"
 inferno = "0.11"
 tempfile = "3"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
-tui-tree-widget = "0.23"
 
 [dev-dependencies]
 insta = "1"

--- a/crates/cli/src/viewer/app.rs
+++ b/crates/cli/src/viewer/app.rs
@@ -1,79 +1,54 @@
 use ratatui::crossterm::event::KeyCode;
 use ratatui::prelude::*;
-use tui_tree_widget::{Tree, TreeItem, TreeState};
 
-use flameview::arena::{FlameTree, NodeId};
+use flameview::arena::FlameTree;
+
+use super::spark_tree_view::SparkTreeView;
 
 pub enum Action {
     None,
     Exit,
-    ToggleHelp,
 }
 
-pub struct App {
-    items: Vec<TreeItem<'static, String>>,
-    state: TreeState<String>,
-    #[allow(dead_code)]
-    show_help: bool,
+pub struct App<'a> {
+    view: SparkTreeView<'a>,
 }
 
-impl App {
-    pub fn new(tree: &FlameTree) -> Self {
-        let items = vec![to_tree_item(tree, tree.root())];
-        let mut state = TreeState::default();
-        state.open(vec!["root".to_string()]);
+impl<'a> App<'a> {
+    pub fn new(tree: &'a FlameTree, max_lines: usize, coverage: f64) -> Self {
         Self {
-            items,
-            state,
-            show_help: false,
+            view: SparkTreeView::new(tree, max_lines, coverage),
         }
     }
 
     pub fn draw(&mut self, f: &mut Frame) {
-        let widget = Tree::new(&self.items).expect("tree");
-        f.render_stateful_widget(widget, f.area(), &mut self.state);
+        self.view.draw(f);
     }
 
     pub fn on_key(&mut self, key: KeyCode) -> Action {
         match key {
             KeyCode::Char('q') | KeyCode::Char('Q') => Action::Exit,
-            KeyCode::Char('h') => {
-                self.show_help = !self.show_help;
-                Action::ToggleHelp
-            }
-            KeyCode::Left => {
-                self.state.key_left();
-                Action::None
-            }
-            KeyCode::Right => {
-                self.state.key_right();
+            KeyCode::Down => {
+                self.view.down();
                 Action::None
             }
             KeyCode::Up => {
-                self.state.key_up();
+                self.view.up();
                 Action::None
             }
-            KeyCode::Down => {
-                self.state.key_down();
+            KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
+                self.view.expand();
+                Action::None
+            }
+            KeyCode::Left | KeyCode::Char('h') | KeyCode::Backspace => {
+                self.view.collapse();
+                Action::None
+            }
+            KeyCode::Char('s') => {
+                self.view.toggle_spark();
                 Action::None
             }
             _ => Action::None,
         }
-    }
-}
-
-fn to_tree_item(tree: &FlameTree, id: NodeId) -> TreeItem<'static, String> {
-    let node = &tree[id];
-    let mut children = Vec::new();
-    let mut child = node.first_child;
-    while let Some(cid) = child {
-        children.push(to_tree_item(tree, cid));
-        child = tree[cid].next_sibling;
-    }
-    let label = format!("{} ({})", node.name, node.total_count);
-    if children.is_empty() {
-        TreeItem::new_leaf(node.name.clone(), label)
-    } else {
-        TreeItem::new(node.name.clone(), label, children).expect("children unique")
     }
 }

--- a/crates/cli/src/viewer/mod.rs
+++ b/crates/cli/src/viewer/mod.rs
@@ -15,6 +15,7 @@ use flameview::loader::{self, collapsed};
 use crate::{run, ViewArgs};
 
 mod app;
+pub mod spark_tree_view;
 use app::{Action, App};
 
 #[cfg(debug_assertions)]
@@ -43,7 +44,7 @@ pub fn tui(args: &ViewArgs) -> anyhow::Result<()> {
 
     enable_raw_mode()?;
     let mut terminal = setup_terminal()?;
-    let mut app = App::new(&tree);
+    let mut app = App::new(&tree, args.max_lines, args.coverage);
 
     let res = run_app(&mut terminal, &mut app);
     restore_terminal(&mut terminal)?;

--- a/crates/cli/src/viewer/spark_tree_view.rs
+++ b/crates/cli/src/viewer/spark_tree_view.rs
@@ -1,0 +1,294 @@
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+use ratatui::prelude::*;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+
+use flameview::arena::{FlameTree, NodeId};
+
+pub const MAX_BAR: usize = 15;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RowState {
+    Expanded,
+    Collapsed,
+    Other,
+}
+
+pub struct Row<'a> {
+    pub depth: usize,
+    pub name: Cow<'a, str>,
+    pub cum_pct: f64,
+    pub self_pct: f64,
+    pub node_id: NodeId,
+    state: RowState,
+}
+
+pub struct SparkTreeView<'a> {
+    tree: &'a FlameTree,
+    root: NodeId,
+    rows: Vec<Row<'a>>,
+    cursor: usize,
+    show_spark: bool,
+    open: HashSet<NodeId>,
+    open_other: HashSet<NodeId>,
+    max_lines: usize,
+    coverage: f64,
+}
+
+impl<'a> SparkTreeView<'a> {
+    pub fn new(tree: &'a FlameTree, max_lines: usize, coverage: f64) -> Self {
+        let root = tree.root();
+        let mut view = SparkTreeView {
+            tree,
+            root,
+            rows: Vec::new(),
+            cursor: 0,
+            show_spark: true,
+            open: HashSet::new(),
+            open_other: HashSet::new(),
+            max_lines,
+            coverage,
+        };
+        view.open.insert(root);
+        view.rebuild();
+        view
+    }
+
+    fn rebuild(&mut self) {
+        self.rows.clear();
+        let total = self.tree[self.root].total_count as f64;
+        self.build_rows(self.root, 0, total);
+        if self.cursor >= self.rows.len() {
+            self.cursor = self.rows.len().saturating_sub(1);
+        }
+    }
+
+    fn build_rows(&mut self, id: NodeId, depth: usize, total: f64) {
+        let node = &self.tree[id];
+        let cum_pct = node.total_count as f64 / total * 100.0;
+        let self_pct = node.self_count as f64 / total * 100.0;
+        let has_children = node.first_child.is_some();
+        let expanded = self.open.contains(&id);
+        let state = if has_children {
+            if expanded {
+                RowState::Expanded
+            } else {
+                RowState::Collapsed
+            }
+        } else {
+            RowState::Collapsed
+        };
+        let name = Cow::Borrowed(node.name.as_str());
+        self.rows.push(Row {
+            depth,
+            name,
+            cum_pct,
+            self_pct,
+            node_id: id,
+            state,
+        });
+        if !has_children || !expanded {
+            return;
+        }
+
+        // collect children
+        let mut children = Vec::new();
+        let mut child = node.first_child;
+        while let Some(cid) = child {
+            children.push(cid);
+            child = self.tree[cid].next_sibling;
+        }
+        children.sort_by_key(|&cid| std::cmp::Reverse(self.tree[cid].total_count));
+
+        let mut displayed = Vec::new();
+        let mut shown = 0usize;
+        let mut running = 0u64;
+        if self.open_other.contains(&id) {
+            displayed = children.clone();
+        } else {
+            for &cid in &children {
+                if shown >= self.max_lines.saturating_sub(1) {
+                    break;
+                }
+                if (running as f64) / (node.total_count as f64) >= self.coverage {
+                    break;
+                }
+                running += self.tree[cid].total_count;
+                displayed.push(cid);
+                shown += 1;
+            }
+        }
+        let mut undisplayed = Vec::new();
+        if displayed.len() < children.len() {
+            for cid in children {
+                if !displayed.contains(&cid) {
+                    undisplayed.push(cid);
+                }
+            }
+        }
+
+        for cid in displayed {
+            self.build_rows(cid, depth + 1, total);
+        }
+
+        if !undisplayed.is_empty() && !self.open_other.contains(&id) {
+            let mut tot: u64 = 0;
+            let mut self_tot: u64 = 0;
+            for cid in &undisplayed {
+                tot += self.tree[*cid].total_count;
+                self_tot += self.tree[*cid].self_count;
+            }
+            let cum_pct = tot as f64 / total * 100.0;
+            let self_pct = self_tot as f64 / total * 100.0;
+            self.rows.push(Row {
+                depth: depth + 1,
+                name: Cow::Borrowed("… Other"),
+                cum_pct,
+                self_pct,
+                node_id: id,
+                state: RowState::Other,
+            });
+        }
+    }
+
+    pub fn draw(&mut self, f: &mut Frame) {
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(
+            "cum% self%   function                     spark",
+        ));
+        for (i, row) in self.rows.iter().enumerate() {
+            let indent = "  ".repeat(row.depth);
+            let label = match row.state {
+                RowState::Expanded => format!("{indent}▼ {}", row.name),
+                RowState::Collapsed => {
+                    if self.tree[row.node_id].first_child.is_some() {
+                        format!("{indent}▶ {}", row.name)
+                    } else {
+                        format!("{indent}  {}", row.name)
+                    }
+                }
+                RowState::Other => format!("{indent}{}", row.name),
+            };
+            let cum = format!("{:>4.0}", row.cum_pct.round());
+            let selfp = format!("{:>4.0}", row.self_pct.round());
+            let spark = if self.show_spark {
+                make_spark(row.self_pct, row.cum_pct)
+            } else {
+                " ".repeat(MAX_BAR)
+            };
+            let text = format!("{cum} {selfp}   {label:<25}{spark:>MAX_BAR$}");
+            let mut line = Line::from(text);
+            if i == self.cursor + 1 {
+                line.style = Style::default().reversed();
+            }
+            lines.push(line);
+        }
+        let paragraph = Paragraph::new(lines);
+        f.render_widget(paragraph, f.area());
+    }
+
+    pub fn up(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.cursor = self.cursor.wrapping_add(self.rows.len() - 1) % self.rows.len();
+    }
+
+    pub fn down(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.cursor = self.cursor.wrapping_add(1) % self.rows.len();
+    }
+
+    pub fn toggle_spark(&mut self) {
+        self.show_spark = !self.show_spark;
+    }
+
+    pub fn expand(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let row = &self.rows[self.cursor];
+        match row.state {
+            RowState::Collapsed => {
+                if self.tree[row.node_id].first_child.is_some() {
+                    self.open.insert(row.node_id);
+                    self.rebuild();
+                }
+            }
+            RowState::Other => {
+                self.open_other.insert(row.node_id);
+                self.rebuild();
+            }
+            RowState::Expanded => {}
+        }
+    }
+
+    pub fn collapse(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let row = &self.rows[self.cursor];
+        match row.state {
+            RowState::Expanded => {
+                self.open.remove(&row.node_id);
+                self.rebuild();
+            }
+            RowState::Collapsed | RowState::Other => {
+                if row.depth > 0 {
+                    let target_depth = row.depth - 1;
+                    let mut idx = self.cursor;
+                    while idx > 0 {
+                        idx -= 1;
+                        if self.rows[idx].depth == target_depth {
+                            self.cursor = idx;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn current_row(&self) -> Option<&Row<'a>> {
+        self.rows.get(self.cursor)
+    }
+
+    pub fn rows(&self) -> &[Row<'a>] {
+        &self.rows
+    }
+}
+
+pub fn make_spark(self_pct: f64, cum_pct: f64) -> String {
+    if cum_pct <= 0.0 {
+        return " ".repeat(MAX_BAR);
+    }
+    let bar_chars = ((cum_pct / 100.0) * MAX_BAR as f64 + 1e-6).round() as usize;
+    if bar_chars == 0 {
+        return " ".repeat(MAX_BAR);
+    }
+    let self_chars = ((self_pct / cum_pct) * bar_chars as f64 + 1e-6).round() as usize;
+    let self_chars = self_chars.min(bar_chars);
+    let mut s = String::new();
+    for i in 0..bar_chars {
+        if i < self_chars {
+            s.push('█');
+        } else {
+            s.push('░');
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_spark() {
+        assert_eq!(make_spark(25.0, 50.0), "████░░░░");
+    }
+}

--- a/crates/cli/src/viewer/test_harness.rs
+++ b/crates/cli/src/viewer/test_harness.rs
@@ -37,7 +37,7 @@ where
     })?;
 
     let mut term = Terminal::new(backend)?;
-    let mut app = App::new(&tree);
+    let mut app = App::new(&tree, args.max_lines, args.coverage);
     let mut buffers = Vec::new();
 
     for ev in script {

--- a/crates/cli/tests/snapshots/tui_navigation.snap
+++ b/crates/cli/tests/snapshots/tui_navigation.snap
@@ -2,37 +2,12 @@
 source: crates/cli/tests/tui_nav_snapshot.rs
 expression: ascii
 ---
-▼ root (34)
-  ▶ java (27)
-  ▶ ab (7)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
---- frame ---
-▼ root (34)
-  ▶ java (27)
-  ▶ ab (7)
-
-
-
+cum% self%   function                     spark
+ 100    0   ▼ root                   ░░░░░░░░░░░░░░░
+  57   14     ▶ foo                        ██░░░░░░░
+  14   14       zzz                               ██
+  14   14       qux                               ██
+  14   14       baz                               ██
 
 
 
@@ -52,37 +27,12 @@ expression: ascii
 
 
 --- frame ---
-▼ root (34)
-  ▶ java (27)
-  ▶ ab (7)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
---- frame ---
-▼ root (34)
-  ▼ java (27)
-    ▶ start_thread (27)
-  ▶ ab (7)
-
-
+cum% self%   function                     spark
+ 100    0   ▼ root                   ░░░░░░░░░░░░░░░
+  57   14     ▶ foo                        ██░░░░░░░
+  14   14       zzz                               ██
+  14   14       qux                               ██
+  14   14       baz                               ██
 
 
 
@@ -102,7 +52,34 @@ expression: ascii
 
 
 --- frame ---
-▼ root (34)
-  ▼ java (27)
-    ▶ start_thread (27)
-  ▶ ab (7)
+cum% self%   function                     spark
+ 100    0   ▼ root                   ░░░░░░░░░░░░░░░
+  57   14     ▼ foo                        ██░░░░░░░
+  43   43         bar                         ██████
+  14   14       zzz                               ██
+  14   14       qux                               ██
+  14   14       baz                               ██
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+--- frame ---
+cum% self%   function                     spark
+ 100    0   ▼ root                   ░░░░░░░░░░░░░░░
+  57   14     ▶ foo                        ██░░░░░░░
+  14   14       zzz                               ██
+  14   14       qux                               ██
+  14   14       baz                               ██

--- a/crates/cli/tests/snapshots/tui_spark_tree.snap
+++ b/crates/cli/tests/snapshots/tui_spark_tree.snap
@@ -1,0 +1,36 @@
+---
+source: crates/cli/tests/tui_spark_tree_snapshot.rs
+expression: ascii
+---
+cum% self%   function                     spark
+ 100    0   ▼ root                   ░░░░░░░░░░░░░░░
+  57   14     ▶ foo                        ██░░░░░░░
+  14   14       zzz                               ██
+  14   14       qux                               ██
+  14   14     … Other                             ██
+
+
+
+
+
+
+--- frame ---
+cum% self%   function                     spark
+ 100    0   ▼ root
+  57   14     ▶ foo
+  14   14       zzz
+  14   14       qux
+  14   14     … Other
+
+
+
+
+
+
+--- frame ---
+cum% self%   function                     spark
+ 100    0   ▼ root
+  57   14     ▶ foo
+  14   14       zzz
+  14   14       qux
+  14   14       baz

--- a/crates/cli/tests/tui_agg_property.rs
+++ b/crates/cli/tests/tui_agg_property.rs
@@ -1,0 +1,36 @@
+#![cfg(all(not(windows), not(miri)))]
+
+use std::fs;
+use std::path::PathBuf;
+
+use flameview::loader::collapsed;
+use flameview_cli::viewer::spark_tree_view::SparkTreeView;
+
+#[test]
+fn tui_agg_property() {
+    let data_path: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "..",
+        "..",
+        "tests",
+        "data",
+        "small.txt",
+    ]
+    .iter()
+    .collect();
+    let data = fs::read(&data_path).unwrap();
+    let tree = collapsed::load_slice(&data).unwrap();
+    for cov in [0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99] {
+        let view = SparkTreeView::new(&tree, 4, cov);
+        let sum: f64 = view
+            .rows()
+            .iter()
+            .filter(|r| r.depth == 1)
+            .map(|r| r.cum_pct)
+            .sum();
+        assert!(
+            (sum - 100.0).abs() <= 0.01,
+            "coverage {cov} produced sum {sum}"
+        );
+    }
+}

--- a/crates/cli/tests/tui_spark_tree_snapshot.rs
+++ b/crates/cli/tests/tui_spark_tree_snapshot.rs
@@ -8,7 +8,7 @@ use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 #[test]
-fn tui_navigation_snapshot() {
+fn tui_spark_tree_snapshot() {
     let data_path: PathBuf = [
         env!("CARGO_MANIFEST_DIR"),
         "..",
@@ -22,14 +22,17 @@ fn tui_navigation_snapshot() {
     let args = ViewArgs {
         file: data_path,
         summarize: false,
-        max_lines: 50,
-        coverage: 0.95,
+        max_lines: 4,
+        coverage: 0.9,
     };
-    let backend = TestBackend::new(80, 24);
+    let backend = TestBackend::new(80, 12);
     let script = vec![
+        KeyEvent::from(KeyCode::Char('s')),
+        KeyEvent::from(KeyCode::Down),
+        KeyEvent::from(KeyCode::Down),
+        KeyEvent::from(KeyCode::Down),
         KeyEvent::from(KeyCode::Down),
         KeyEvent::from(KeyCode::Right),
-        KeyEvent::from(KeyCode::Char('h')),
         KeyEvent::from(KeyCode::Char('q')),
     ];
     let frames = run_with_backend(&args, backend, script).expect("run");
@@ -50,12 +53,13 @@ fn tui_navigation_snapshot() {
         }
         out
     }
-    let ascii = frames
+    let indices = [0usize, 1, 6];
+    let ascii = indices
         .iter()
-        .map(buf_to_string)
+        .map(|&i| buf_to_string(&frames[i]))
         .collect::<Vec<_>>()
         .join("\n--- frame ---\n");
     insta::with_settings!({ prepend_module_to_snapshot => false }, {
-        insta::assert_snapshot!("tui_navigation", ascii);
+        insta::assert_snapshot!("tui_spark_tree", ascii);
     });
 }

--- a/tests/data/small_self.txt
+++ b/tests/data/small_self.txt
@@ -1,0 +1,5 @@
+foo;bar 3
+foo 1
+baz 1
+qux 1
+zzz 1


### PR DESCRIPTION
## Summary
- replace tree widget with list-based `SparkTreeView` featuring sparkline column and hierarchical navigation
- support sparkline toggling and "… Other" aggregation with tests
- add property test ensuring visible cumulative percent sums to ~100%
- show non-zero self percentages in snapshots using dedicated test data

## Testing
- `cargo test -q --test tui_nav_snapshot --test tui_spark_tree_snapshot`
- `cargo test -q`
- `bash .agent/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68912c07adc0832099a6a921826aa3fd